### PR TITLE
fixed problem where runMain gbvga.GbVgaDriver failed

### DIFF
--- a/chisel/build.sbt
+++ b/chisel/build.sbt
@@ -42,8 +42,8 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.4.0-RC1",
-  "chisel-iotesters" -> "1.5.0-RC1",
+  "chisel3" -> "3.4-SNAPSHOT",
+  "chisel-iotesters" -> "1.5-SNAPSHOT",
   "chisel-formal" -> "0.1-SNAPSHOT",
   )
 

--- a/chisel/src/main/scala/gbvga/gbinclude.scala
+++ b/chisel/src/main/scala/gbvga/gbinclude.scala
@@ -17,7 +17,7 @@ class Gb extends Bundle {
   val data  = UInt(2.W)
 }
 
-object GbConst {
+trait GbConst { self: RawModule =>
   val GBWIDTH   = 160
   val GBHEIGHT = 144
 

--- a/chisel/src/main/scala/gbvga/gbvga.scala
+++ b/chisel/src/main/scala/gbvga/gbvga.scala
@@ -4,8 +4,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
-
 class GbVga extends Module {
   val io = IO(new Bundle {
     /* Game boy input signals */

--- a/chisel/src/main/scala/gbvga/gbwrite.scala
+++ b/chisel/src/main/scala/gbvga/gbwrite.scala
@@ -5,11 +5,9 @@ import chisel3.util._
 import chisel3.formal._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
-
 class GbWrite (val datawidth: Int = 2,
                val debug_simu: Boolean = true,
-               val aformal: Boolean = false) extends Module {//with Formal {
+               val aformal: Boolean = false) extends Module with GbConst {//with Formal {
   val io = IO(new Bundle {
     /* GameBoy input */
     val gb = Input(new Gb())

--- a/chisel/src/main/scala/gbvga/hvsync.scala
+++ b/chisel/src/main/scala/gbvga/hvsync.scala
@@ -11,8 +11,6 @@ import chisel3.util._
 import chisel3.formal.Formal
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
-
 class HVSync extends Module { // with Formal { scala version problem
   val io = IO(new Bundle {
      val hsync = Output(Bool())

--- a/chisel/src/main/scala/gbvga/memvga.scala
+++ b/chisel/src/main/scala/gbvga/memvga.scala
@@ -4,9 +4,8 @@ import chisel3._
 import chisel3.util._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
 
-class MemVga extends Module {
+class MemVga extends Module with GbConst {
   val io = IO(new Bundle {
     /* memory read interface */
     val mem_addr  = Output(UInt((log2Ceil(GBWIDTH*GBHEIGHT)).W))
@@ -84,21 +83,21 @@ class MemVga extends Module {
   /* Vga colors */
   io.vga_color := VGA_BLACK
   when(hvsync.io.display_on && (state===sPixInc)){
-//    io.vga_color := GbColors(io.mem_data)
-    switch(io.mem_data) {
-      is("b00".U) {
-        io.vga_color := GB_GREEN0
-      }
-      is("b01".U) {
-        io.vga_color := GB_GREEN1
-      }
-      is("b10".U) {
-        io.vga_color := GB_GREEN2
-      }
-      is("b11".U) {
-        io.vga_color := GB_GREEN3
-      }
-    }
+    io.vga_color := GbColors(io.mem_data)
+//    switch(io.mem_data) {
+//      is("b00".U) {
+//        io.vga_color := GB_GREEN0
+//      }
+//      is("b01".U) {
+//        io.vga_color := GB_GREEN1
+//      }
+//      is("b10".U) {
+//        io.vga_color := GB_GREEN2
+//      }
+//      is("b11".U) {
+//        io.vga_color := GB_GREEN3
+//      }
+//    }
   }
 
   /* Memory interface */

--- a/chisel/src/main/scala/gbvga/rawgbvga.scala
+++ b/chisel/src/main/scala/gbvga/rawgbvga.scala
@@ -9,9 +9,7 @@ import chisel3.util._
 import chisel3.formal.Formal
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
-
-class RawGbVga extends RawModule {
+class RawGbVga extends RawModule with GbConst {
 
   /************/
   /** outputs */

--- a/chisel/src/main/scala/gbvga/simplevga.scala
+++ b/chisel/src/main/scala/gbvga/simplevga.scala
@@ -9,8 +9,6 @@ import chisel3.util._
 import chisel3.formal.Formal
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 
-import GbConst._
-
 class SimpleVGA extends RawModule {
   /************/
   /** outputs */


### PR DESCRIPTION
- point sbt dependencies to snapshots instead of RC-1
- Changed GbConst to trait
    - fixed up all references to GbConst
  - Think problem was bundles declared outside of modules
- another approach might be to make GbConst its own module
